### PR TITLE
fix: audit

### DIFF
--- a/contracts/account/src/auth.rs
+++ b/contracts/account/src/auth.rs
@@ -109,7 +109,13 @@ impl Authenticator {
                 }
             }
             Authenticator::EthWallet { address } => {
-                let addr_bytes = hex::decode(&address[2..])?;
+                if !address.starts_with("0x") || address.len() != 42 {
+                    return Err(ContractError::InvalidEthAddress);
+                }
+                let normalized_address = address.to_lowercase();
+                let addr_bytes = hex::decode(&normalized_address[2..])
+                    .map_err(|_| ContractError::InvalidEthAddress)?;
+
                 match eth_crypto::verify(deps.api, tx_bytes, sig_bytes, &addr_bytes) {
                     Ok(_) => Ok(true),
                     Err(error) => Err(error),

--- a/contracts/account/src/error.rs
+++ b/contracts/account/src/error.rs
@@ -84,6 +84,9 @@ pub enum ContractError {
 
     #[error(transparent)]
     FromUTF8(#[from] std::string::FromUtf8Error),
+
+    #[error("invalid ethereum address")]
+    InvalidEthAddress,
 }
 
 pub type ContractResult<T> = Result<T, ContractError>;

--- a/contracts/account/src/execute.rs
+++ b/contracts/account/src/execute.rs
@@ -193,7 +193,8 @@ pub fn add_auth_method(
             )? {
                 Err(ContractError::InvalidSignature)
             } else {
-                AUTHENTICATORS.save(deps.storage, *id, &auth)?;
+                save_authenticator(deps, *id, &auth)?;
+
                 Ok(())
             }
         }


### PR DESCRIPTION
This PR addresses two key issues identified during the contract audit:

## Fix Secp256R1 Overriding Index Bypass:
- Ensured that all authenticator additions, including Secp256R1, now utilize the save_authenticator function to prevent bypassing the OverridingIndex check.

## Enhance EthWallet Address Validation:
- Ensured that addresses start with 0x and have the correct length of 42 characters.
- Normalized addresses to lowercase to prevent inconsistent tracking.