### PR TITLE
Add Fractible and Fractit Inception Pass contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ docker run --rm -v "$(pwd)":/code \
 | Talis Staking | Talis Staking | [f084f5b](https://github.com/Talis-Art/talis_contracts_v2/commit/f084f5b7950f911b16090dfd38e1c06a177a1da8) | [Talis](https://talis.art/) | `49` | `9C9047420A5B870D490585C753FFB46C97E310A55E9FCF50EA784BAFC2A701FD` | Genesis |
 | Talis Frens Proxy | Talis Frens Proxy | [f084f5b](https://github.com/Talis-Art/talis_contracts_v2/commit/f084f5b7950f911b16090dfd38e1c06a177a1da8) | [Talis](https://talis.art/) | `50` | `919FF797B7F35A40B5D32B506C2C05918DAA1C42B89C6864425F2047B5BC19F7` | Genesis |
 | Talis Trading Escrow | Talis Trading Escrow | [f084f5b](https://github.com/Talis-Art/talis_contracts_v2/commit/f084f5b7950f911b16090dfd38e1c06a177a1da8) | [Talis](https://talis.art/) | `51` | `01AA4D93B63871DE8E94B35FECAA0E586C8B4824A8B0EE833416303796B256E2` | Genesis |
+| Fractible | A protocol for the fractional ownership of NFTs | [b62e2bc8aa7646e73bceb07af67137c48c5a7488](https://github.com/Fractit/fractible_xion) | [Fractible](https://fractible.io) | `52` | `F6D5ADDC062B5B45BCA207EAF49B8D2736A2D7F86956FCE4D5176E3D07C91980` | 21 |
+| Fractit Inception Pass | Protocol for managing Fractit Inception Pass NFTs | [2eb952db4592ea3965070c1199117927319f433b](https://github.com/Fractit/fractible_xion) | [Fractit](https://fractit.io) | `53` | `D45A22411A5C430A2C74248A20391618F5E0ECDD1BDC579C87493823E242663F` | 22 |
 
 ## Deprecated Contracts
 | Name | Description | Release | Author | Code ID | Hash | Governance Proposal |

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ docker run --rm -v "$(pwd)":/code \
 | Talis Staking | Talis Staking | [f084f5b](https://github.com/Talis-Art/talis_contracts_v2/commit/f084f5b7950f911b16090dfd38e1c06a177a1da8) | [Talis](https://talis.art/) | `49` | `9C9047420A5B870D490585C753FFB46C97E310A55E9FCF50EA784BAFC2A701FD` | Genesis |
 | Talis Frens Proxy | Talis Frens Proxy | [f084f5b](https://github.com/Talis-Art/talis_contracts_v2/commit/f084f5b7950f911b16090dfd38e1c06a177a1da8) | [Talis](https://talis.art/) | `50` | `919FF797B7F35A40B5D32B506C2C05918DAA1C42B89C6864425F2047B5BC19F7` | Genesis |
 | Talis Trading Escrow | Talis Trading Escrow | [f084f5b](https://github.com/Talis-Art/talis_contracts_v2/commit/f084f5b7950f911b16090dfd38e1c06a177a1da8) | [Talis](https://talis.art/) | `51` | `01AA4D93B63871DE8E94B35FECAA0E586C8B4824A8B0EE833416303796B256E2` | Genesis |
-| Fractible | A protocol for the fractional ownership of NFTs | [b62e2bc8aa7646e73bceb07af67137c48c5a7488](https://github.com/Fractit/fractible_xion) | [Fractible](https://fractible.io) | `52` | `F6D5ADDC062B5B45BCA207EAF49B8D2736A2D7F86956FCE4D5176E3D07C91980` | 21 |
-| Fractit Inception Pass | Protocol for managing Fractit Inception Pass NFTs | [2eb952db4592ea3965070c1199117927319f433b](https://github.com/Fractit/fractible_xion) | [Fractit](https://fractit.io) | `53` | `D45A22411A5C430A2C74248A20391618F5E0ECDD1BDC579C87493823E242663F` | 22 |
+| Fractit | A protocol for the fractional ownership of NFTs | [b62e2bc8aa7646e73bceb07af67137c48c5a7488](https://github.com/Fractit/fractible_xion) | [Fractit](https://fractit.com) | `52` | `F6D5ADDC062B5B45BCA207EAF49B8D2736A2D7F86956FCE4D5176E3D07C91980` | 21 |
+| Fractit Inception Pass | Protocol for managing Fractit Inception Pass NFTs | [2eb952db4592ea3965070c1199117927319f433b](https://github.com/Fractit/fractible_xion) | [Fractit](https://fractit.com) | `53` | `D45A22411A5C430A2C74248A20391618F5E0ECDD1BDC579C87493823E242663F` | 22 |
 
 ## Deprecated Contracts
 | Name | Description | Release | Author | Code ID | Hash | Governance Proposal |

--- a/contracts.json
+++ b/contracts.json
@@ -798,5 +798,37 @@
       "url": "https://talis.art/"
     },
     "deprecated": false
+  },
+  {
+    "name": "Fractible",
+    "description": "A protocol for the fractional ownership of NFTs",
+    "code_id": "52",
+    "hash": "F6D5ADDC062B5B45BCA207EAF49B8D2736A2D7F86956FCE4D5176E3D07C91980",
+    "release": {
+      "url": "https://github.com/Fractit/fractible_xion",
+      "version": "b62e2bc8aa7646e73bceb07af67137c48c5a7488"
+    },
+    "author": {
+      "name": "Fractible",
+      "url": "https://fractible.io"
+    },
+    "governance": "21",
+    "deprecated": false
+  },
+  {
+    "name": "Fractit Inception Pass",
+    "description": "Protocol for managing Fractit Inception Pass NFTs",
+    "code_id": "53",
+    "hash": "D45A22411A5C430A2C74248A20391618F5E0ECDD1BDC579C87493823E242663F",
+    "release": {
+      "url": "https://github.com/Fractit/fractible_xion",
+      "version": "2eb952db4592ea3965070c1199117927319f433b"
+    },
+    "author": {
+      "name": "Fractit",
+      "url": "https://fractit.io"
+    },
+    "governance": "22",
+    "deprecated": false
   }
 ]

--- a/contracts.json
+++ b/contracts.json
@@ -800,7 +800,7 @@
     "deprecated": false
   },
   {
-    "name": "Fractible",
+    "name": "Fractit",
     "description": "A protocol for the fractional ownership of NFTs",
     "code_id": "52",
     "hash": "F6D5ADDC062B5B45BCA207EAF49B8D2736A2D7F86956FCE4D5176E3D07C91980",
@@ -809,8 +809,8 @@
       "version": "b62e2bc8aa7646e73bceb07af67137c48c5a7488"
     },
     "author": {
-      "name": "Fractible",
-      "url": "https://fractible.io"
+      "name": "Fractit",
+      "url": "https://fractit.com"
     },
     "governance": "21",
     "deprecated": false
@@ -826,7 +826,7 @@
     },
     "author": {
       "name": "Fractit",
-      "url": "https://fractit.io"
+      "url": "https://fractit.com"
     },
     "governance": "22",
     "deprecated": false


### PR DESCRIPTION
Adds two new contracts to the repository:
- Fractible (code ID 52): A protocol for fractional NFT ownership
- Fractit Inception Pass (code ID 53): NFT management protocol

Updates contracts.json and README.md with contract details and release information.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Contract Details
Please append all the required information below for the contract(s) being added to `contracts.json`.

Required fields and their descriptions:
- `name`: Contract name (required)
- `description`: Brief description of the contract's purpose
- `code_id`: Contract code ID on mainnet
- `hash`: Contract hash in UPPERCASE
- `release`:
  - `url`: URL to the release/commit (e.g., https://github.com/org/repo/releases/tag/v1.0.0)
  - `version`: Version tag or first 7 chars of commit hash
- `author`:
  - `name`: Organization name
  - `url`: Organization website URL
- `governance`: "Genesis" or proposal number
- `deprecated`: true if contract is deprecated (mixed inline with active contracts)

Example JSON structure:
```json
{
  "name": "",
  "description": "",
  "code_id": "",
  "hash": "",
  "release": {
    "url": "",
    "version": ""
  },
  "author": {
    "name": "",
    "url": ""
  },
  "governance": "",
  "deprecated": false
}
```

### Finding Code ID and Hash
To find the latest code ID and hash:
1. Run the verification tool which will show all code IDs on chain:
   ```bash
   node scripts/verify-code-ids.js
   ```
2. The new code ID will be shown in the mismatches as "exists on chain but not in contracts.json"
3. You can also query the code hash via the chain's RPC endpoint:
   ```bash
   xiond query wasm code-info <code-id> --node https://rpc.xion-mainnet-1.burnt.com
   ```

### Documentation Updates
The README.md is automatically generated from `contracts.json`. After making changes:

1. Ensure you have the required dependencies:
   - Node.js: https://nodejs.org/
   - jq: `brew install jq` (macOS) or `apt-get install jq` (Ubuntu/Debian)

2. Run the convert script to validate and update the README:
   ```bash
   ./convert.sh
   ```

3. Commit both the `contracts.json` and generated `README.md` changes

⚠️ Important Notes:
- Do not edit README.md manually. All changes must be made through `contracts.json`
- Pull requests with manual README edits will be automatically rejected by CI
- If you forget to run `./convert.sh` locally, the CI will fail with a "README out of sync" error

### Validation
The `convert.sh` script automatically performs these validations:
- All required fields are present and properly formatted
- Hash is 64 characters and uppercase hex
- URLs are valid HTTPS links
- Code IDs are unique
- Contracts are ordered by code_id (both active and deprecated contracts follow the same ordering)
- README.md stays in sync with contracts.json

If any validation fails, the script will show specific error messages to help you fix the issues.

### Checklist
- [x] Added entry to `contracts.json` with all required fields
- [x] Contract name is clear and descriptive
- [x] Description explains the contract's purpose
- [x] Code ID matches the mainnet deployed code
- [x] Hash is in uppercase and matches the stored code
- [x] Release URL points to the correct tag/commit
- [x] Version matches the release tag or commit hash
- [x] Author information is correct with valid URL
- [x] Governance field correctly references proposal or "Genesis"
- [x] Deprecated flag is set appropriately
- [x] Entry is placed in code_id order (regardless of deprecated status)
- [x] Ran `./convert.sh` and fixed any validation errors
- [x] Both `contracts.json` and generated `README.md` are included in the commit

### Additional Notes
<!-- Add any additional context or notes about the contract deployment here -->
