### PR TITLE
Require params as part of the init message

### DIFF
--- a/contracts/treasury/src/contract.rs
+++ b/contracts/treasury/src/contract.rs
@@ -27,6 +27,7 @@ pub fn instantiate(
         msg.type_urls,
         msg.grant_configs,
         msg.fee_config,
+        msg.params,
     )
 }
 

--- a/contracts/treasury/src/contract.rs
+++ b/contracts/treasury/src/contract.rs
@@ -59,7 +59,10 @@ pub fn execute(
         ExecuteMsg::RevokeAllowance { grantee } => revoke_allowance(deps, env, info, grantee),
         ExecuteMsg::UpdateParams { params } => update_params(deps, info, params),
         ExecuteMsg::Withdraw { coins } => withdraw_coins(deps, info, coins),
-        ExecuteMsg::Migrate { new_code_id, migrate_msg } => execute::migrate(deps, env, info, new_code_id, migrate_msg),
+        ExecuteMsg::Migrate {
+            new_code_id,
+            migrate_msg,
+        } => execute::migrate(deps, env, info, new_code_id, migrate_msg),
     }
 }
 

--- a/contracts/treasury/src/error.rs
+++ b/contracts/treasury/src/error.rs
@@ -35,7 +35,7 @@ pub enum ContractError {
 
     #[error("grant config for {type_url} not found")]
     GrantConfigNotFound { type_url: String },
-    
+
     #[error(transparent)]
     JsonError(#[from] serde_json::Error),
 }

--- a/contracts/treasury/src/msg.rs
+++ b/contracts/treasury/src/msg.rs
@@ -9,6 +9,7 @@ pub struct InstantiateMsg {
     pub type_urls: Vec<String>,
     pub grant_configs: Vec<GrantConfig>,
     pub fee_config: FeeConfig,
+    pub params: Params,
 }
 
 #[cw_serde]


### PR DESCRIPTION
This pull request introduces support for managing `params` in the Treasury contract by adding it to the instantiation process, validating it, and enabling updates. The changes span multiple files and functions to ensure proper integration and validation of the new `params` field.

### Enhancements to `params` management:

* **Added `params` to instantiation:**
  - Updated `pub fn instantiate` in `contracts/treasury/src/contract.rs` to include `msg.params` in the instantiation process.
  - Modified the `InstantiateMsg` struct in `contracts/treasury/src/msg.rs` to include a new `params` field.

* **Validation and storage of `params`:**
  - Introduced `validate_params` function in `contracts/treasury/src/execute.rs` to validate URLs and metadata in the `params` field.
  - Updated `pub fn init` in `contracts/treasury/src/execute.rs` to validate and store `params` during initialization.

* **Support for updating `params`:**
  - Refactored `pub fn update_params` in `contracts/treasury/src/execute.rs` to include validation using the new `validate_params` function before saving updated `params`.