### PR TITLE
Feature/add execute on account

### DIFF
--- a/contracts/treasury/src/contract.rs
+++ b/contracts/treasury/src/contract.rs
@@ -64,6 +64,9 @@ pub fn execute(
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
+        QueryMsg::RawGrantConfigByTypeUrl { msg_type_url } => to_json_binary(
+            &query::raw_grant_config_by_type_url(deps.storage, msg_type_url)?,
+        ),
         QueryMsg::GrantConfigByTypeUrl {
             msg_type_url,
             account_address,
@@ -75,7 +78,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::GrantConfigTypeUrls {} => {
             to_json_binary(&query::grant_config_type_urls(deps.storage)?)
         }
-        QueryMsg::FeeConfig {} => to_json_binary(&query::fee_config(deps.storage)?),
+        QueryMsg::FeeConfig { address } => {
+            to_json_binary(&query::fee_config(deps.storage, address)?)
+        }
+        QueryMsg::RawFeeConfig {} => to_json_binary(&query::raw_fee_config(deps.storage)?),
         QueryMsg::Admin {} => to_json_binary(&query::admin(deps.storage)?),
         QueryMsg::PendingAdmin {} => to_json_binary(&query::pending_admin(deps.storage)?),
         QueryMsg::Params {} => to_json_binary(&query::params(deps.storage)?),

--- a/contracts/treasury/src/contract.rs
+++ b/contracts/treasury/src/contract.rs
@@ -64,9 +64,14 @@ pub fn execute(
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::GrantConfigByTypeUrl { msg_type_url } => to_json_binary(
-            &query::grant_config_by_type_url(deps.storage, msg_type_url)?,
-        ),
+        QueryMsg::GrantConfigByTypeUrl {
+            msg_type_url,
+            account_address,
+        } => to_json_binary(&query::grant_config_by_type_url(
+            deps.storage,
+            msg_type_url,
+            account_address,
+        )?),
         QueryMsg::GrantConfigTypeUrls {} => {
             to_json_binary(&query::grant_config_type_urls(deps.storage)?)
         }

--- a/contracts/treasury/src/error.rs
+++ b/contracts/treasury/src/error.rs
@@ -1,3 +1,5 @@
+use cosmwasm_std::StdError;
+
 #[derive(Debug, thiserror::Error)]
 pub enum ContractError {
     #[error(transparent)]
@@ -38,3 +40,12 @@ pub enum ContractError {
 }
 
 pub type ContractResult<T> = Result<T, ContractError>;
+
+impl From<ContractError> for StdError {
+    fn from(val: ContractError) -> Self {
+        match val {
+            ContractError::Std(err) => err,
+            _ => StdError::generic_err(val.to_string()),
+        }
+    }
+}

--- a/contracts/treasury/src/execute.rs
+++ b/contracts/treasury/src/execute.rs
@@ -4,7 +4,7 @@ use crate::error::ContractError::{
 };
 use crate::error::ContractResult;
 use crate::grant::allowance::format_allowance;
-use crate::grant::{FeeConfig, GrantConfigStorage};
+use crate::grant::{FeeConfigStorage, GrantConfigStorage};
 use crate::state::{Params, ADMIN, FEE_CONFIG, GRANT_CONFIGS, PARAMS, PENDING_ADMIN};
 use cosmos_sdk_proto::cosmos::authz::v1beta1::{QueryGrantsRequest, QueryGrantsResponse};
 use cosmos_sdk_proto::cosmos::feegrant::v1beta1::QueryAllowanceRequest;
@@ -23,7 +23,7 @@ pub fn init(
     admin: Option<Addr>,
     type_urls: Vec<String>,
     grant_configs: Vec<GrantConfigStorage>,
-    fee_config: FeeConfig,
+    fee_config: FeeConfigStorage,
 ) -> ContractResult<Response> {
     let treasury_admin = match admin {
         None => info.sender,
@@ -165,7 +165,7 @@ pub fn remove_grant_config(
 pub fn update_fee_config(
     deps: DepsMut,
     info: MessageInfo,
-    fee_config: FeeConfig,
+    fee_config: FeeConfigStorage,
 ) -> ContractResult<Response> {
     let admin = ADMIN.load(deps.storage)?;
     if admin != info.sender {
@@ -246,6 +246,7 @@ pub fn deploy_fee_grant(
                         None => return Err(AuthzGrantNotFound { msg_type_url }),
                         Some(auth) => {
                             // the authorization must match the one in the config
+                            // Here authz_granter is supposed to be the abstract account (giving permissions)
                             if grant_config
                                 .try_into_grant_config(authz_granter.to_string())?
                                 .authorization
@@ -263,7 +264,12 @@ pub fn deploy_fee_grant(
 
     let fee_config = FEE_CONFIG.load(deps.storage)?;
     // create feegrant, if needed
-    match fee_config.allowance {
+    // Here authz_granter is supposed to be the abstract account (giving authz permissions)
+    match fee_config
+        .allowance
+        .map(|a| a.try_into_any(authz_granter.to_string()))
+        .transpose()?
+    {
         // this treasury doesn't deploy any fees, and can return
         None => Ok(Response::new()),
         // allowance should be stored as a prost proto from the feegrant definition

--- a/contracts/treasury/src/execute.rs
+++ b/contracts/treasury/src/execute.rs
@@ -4,7 +4,7 @@ use crate::error::ContractError::{
 };
 use crate::error::ContractResult;
 use crate::grant::allowance::format_allowance;
-use crate::grant::{FeeConfig, GrantConfig};
+use crate::grant::{FeeConfig, GrantConfigStorage};
 use crate::state::{Params, ADMIN, FEE_CONFIG, GRANT_CONFIGS, PARAMS, PENDING_ADMIN};
 use cosmos_sdk_proto::cosmos::authz::v1beta1::{QueryGrantsRequest, QueryGrantsResponse};
 use cosmos_sdk_proto::cosmos::feegrant::v1beta1::QueryAllowanceRequest;
@@ -22,7 +22,7 @@ pub fn init(
     info: MessageInfo,
     admin: Option<Addr>,
     type_urls: Vec<String>,
-    grant_configs: Vec<GrantConfig>,
+    grant_configs: Vec<GrantConfigStorage>,
     fee_config: FeeConfig,
 ) -> ContractResult<Response> {
     let treasury_admin = match admin {
@@ -116,7 +116,7 @@ pub fn update_grant_config(
     deps: DepsMut,
     info: MessageInfo,
     msg_type_url: String,
-    grant_config: GrantConfig,
+    grant_config: GrantConfigStorage,
 ) -> ContractResult<Response> {
     let admin = ADMIN.load(deps.storage)?;
     if admin != info.sender {
@@ -246,7 +246,11 @@ pub fn deploy_fee_grant(
                         None => return Err(AuthzGrantNotFound { msg_type_url }),
                         Some(auth) => {
                             // the authorization must match the one in the config
-                            if grant_config.authorization.ne(&auth.into()) {
+                            if grant_config
+                                .try_into_grant_config(authz_granter.to_string())?
+                                .authorization
+                                .ne(&auth.into())
+                            {
                                 return Err(AuthzGrantMismatch);
                             }
                         }

--- a/contracts/treasury/src/grant.rs
+++ b/contracts/treasury/src/grant.rs
@@ -35,15 +35,13 @@ pub struct GrantConfigStorage {
     pub optional: bool,
 }
 
-impl GrantConfigStorage {
-    pub fn try_into_grant_config(self, address: String) -> ContractResult<GrantConfig> {
-        Ok(GrantConfig {
-            description: self.description,
-            authorization: match self.authorization {
-                AuthorizationData::Any(any) => any,
-                AuthorizationData::ExecuteOnAccount(auth) => {
-                    // Handle the case where authorization is on the account itself
-                    Any {
+impl AuthorizationData {
+    pub fn try_into_any(self, address: String) -> ContractResult<Any> {
+        Ok(match self {
+            AuthorizationData::Any(any) => any,
+            AuthorizationData::ExecuteOnAccount(auth) => {
+                // Handle the case where authorization is on the account itself
+                Any {
                         type_url: cosmos_sdk_proto::cosmwasm::wasm::v1::ContractExecutionAuthorization::full_name(),
                         value:
                             cosmos_sdk_proto::cosmwasm::wasm::v1::ContractExecutionAuthorization {
@@ -56,11 +54,26 @@ impl GrantConfigStorage {
                             .to_bytes()?
                             .into(),
                     }
-                }
-            },
+            }
+        })
+    }
+}
+
+impl GrantConfigStorage {
+    pub fn try_into_grant_config(self, address: String) -> ContractResult<GrantConfig> {
+        Ok(GrantConfig {
+            description: self.description,
+            authorization: self.authorization.try_into_any(address)?,
             optional: self.optional,
         })
     }
+}
+
+#[cw_serde]
+pub struct FeeConfigStorage {
+    description: String,
+    pub allowance: Option<AllowanceData>,
+    pub expiration: Option<u32>,
 }
 
 #[cw_serde]
@@ -68,6 +81,50 @@ pub struct FeeConfig {
     description: String,
     pub allowance: Option<Any>,
     pub expiration: Option<u32>,
+}
+
+#[cw_serde]
+pub enum AllowanceData {
+    Any(Any),
+    AllowanceOnAccount(AllowanceOnAccount),
+}
+#[cw_serde]
+pub struct AllowanceOnAccount {
+    pub allowance: Option<Any>,
+}
+
+impl FeeConfigStorage {
+    pub fn try_into_fee_config(self, address: String) -> ContractResult<FeeConfig> {
+        Ok(FeeConfig {
+            description: self.description,
+            allowance: match self.allowance {
+                None => None,
+                Some(allowance) => Some(allowance.try_into_any(address)?),
+            },
+            expiration: self.expiration,
+        })
+    }
+}
+
+impl AllowanceData {
+    pub fn try_into_any(self, address: String) -> ContractResult<Any> {
+        Ok(match self {
+            AllowanceData::Any(any) => any,
+            AllowanceData::AllowanceOnAccount(allowance) => {
+                // Handle the case where authorization is on the account itself
+                Any {
+                    type_url: cosmos_sdk_proto::cosmwasm::wasm::v1::ContractExecutionAuthorization::full_name(),
+                    value:
+                        cosmos_sdk_proto::xion::v1::ContractsAllowance {
+                            allowance: allowance.allowance.map(Into::into),
+                            contract_addresses: vec![address]
+                        }
+                        .to_bytes()?
+                        .into(),
+                }
+            }
+        })
+    }
 }
 
 #[cw_serde]

--- a/contracts/treasury/src/grant.rs
+++ b/contracts/treasury/src/grant.rs
@@ -1,13 +1,66 @@
 pub mod allowance;
 
+use cosmos_sdk_proto::{prost::Name, traits::MessageExt};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Binary;
+
+use crate::error::ContractResult;
 
 #[cw_serde]
 pub struct GrantConfig {
     description: String,
     pub authorization: Any,
     pub optional: bool,
+}
+
+#[cw_serde]
+
+pub enum AuthorizationData {
+    Any(Any),
+    ExecuteOnAccount(AuthorizationOnAccount),
+}
+
+#[cw_serde]
+
+pub struct AuthorizationOnAccount {
+    pub limit: Option<Any>,
+    pub filter: Option<Any>,
+}
+
+#[cw_serde]
+
+pub struct GrantConfigStorage {
+    pub description: String,
+    pub authorization: AuthorizationData,
+    pub optional: bool,
+}
+
+impl GrantConfigStorage {
+    pub fn try_into_grant_config(self, address: String) -> ContractResult<GrantConfig> {
+        Ok(GrantConfig {
+            description: self.description,
+            authorization: match self.authorization {
+                AuthorizationData::Any(any) => any,
+                AuthorizationData::ExecuteOnAccount(auth) => {
+                    // Handle the case where authorization is on the account itself
+                    Any {
+                        type_url: cosmos_sdk_proto::cosmwasm::wasm::v1::ContractExecutionAuthorization::full_name(),
+                        value:
+                            cosmos_sdk_proto::cosmwasm::wasm::v1::ContractExecutionAuthorization {
+                                grants: vec![cosmos_sdk_proto::cosmwasm::wasm::v1::ContractGrant {
+                                    contract: address,
+                                    limit: auth.limit.map(Into::into),
+                                    filter:auth.filter.map(Into::into),
+                                }],
+                            }
+                            .to_bytes()?
+                            .into(),
+                    }
+                }
+            },
+            optional: self.optional,
+        })
+    }
 }
 
 #[cw_serde]

--- a/contracts/treasury/src/msg.rs
+++ b/contracts/treasury/src/msg.rs
@@ -1,14 +1,14 @@
-use crate::grant::{FeeConfig, GrantConfigStorage};
+use crate::grant::{FeeConfig, FeeConfigStorage, GrantConfig, GrantConfigStorage};
 use crate::state::Params;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Binary, Coin};
+use cosmwasm_std::{Addr, Coin};
 
 #[cw_serde]
 pub struct InstantiateMsg {
     pub admin: Option<Addr>,
     pub type_urls: Vec<String>,
     pub grant_configs: Vec<GrantConfigStorage>,
-    pub fee_config: FeeConfig,
+    pub fee_config: FeeConfigStorage,
 }
 
 #[cw_serde]
@@ -26,7 +26,7 @@ pub enum ExecuteMsg {
         msg_type_url: String,
     },
     UpdateFeeConfig {
-        fee_config: FeeConfig,
+        fee_config: FeeConfigStorage,
     },
     DeployFeeGrant {
         authz_granter: Addr,
@@ -47,24 +47,30 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Query the grant config by type url
-    #[returns(Binary)]
+    #[returns(GrantConfig)]
     GrantConfigByTypeUrl {
         msg_type_url: String,
         account_address: String,
     },
+    /// Query the grant config by type url
+    #[returns(GrantConfigStorage)]
+    RawGrantConfigByTypeUrl { msg_type_url: String },
 
-    #[returns(Binary)]
+    #[returns(Vec<String>)]
     GrantConfigTypeUrls {},
 
-    #[returns(Binary)]
-    FeeConfig {},
+    #[returns(FeeConfig)]
+    FeeConfig { address: String },
 
-    #[returns(Binary)]
+    #[returns(FeeConfigStorage)]
+    RawFeeConfig {},
+
+    #[returns(Addr)]
     Admin {},
 
-    #[returns(Binary)]
+    #[returns(Addr)]
     PendingAdmin {},
 
-    #[returns(Binary)]
+    #[returns(Params)]
     Params {},
 }

--- a/contracts/treasury/src/msg.rs
+++ b/contracts/treasury/src/msg.rs
@@ -1,4 +1,4 @@
-use crate::grant::{FeeConfig, GrantConfig};
+use crate::grant::{FeeConfig, GrantConfigStorage};
 use crate::state::Params;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Binary, Coin};
@@ -7,7 +7,7 @@ use cosmwasm_std::{Addr, Binary, Coin};
 pub struct InstantiateMsg {
     pub admin: Option<Addr>,
     pub type_urls: Vec<String>,
-    pub grant_configs: Vec<GrantConfig>,
+    pub grant_configs: Vec<GrantConfigStorage>,
     pub fee_config: FeeConfig,
 }
 
@@ -20,7 +20,7 @@ pub enum ExecuteMsg {
     CancelProposedAdmin {},
     UpdateGrantConfig {
         msg_type_url: String,
-        grant_config: GrantConfig,
+        grant_config: GrantConfigStorage,
     },
     RemoveGrantConfig {
         msg_type_url: String,
@@ -48,7 +48,10 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     /// Query the grant config by type url
     #[returns(Binary)]
-    GrantConfigByTypeUrl { msg_type_url: String },
+    GrantConfigByTypeUrl {
+        msg_type_url: String,
+        account_address: String,
+    },
 
     #[returns(Binary)]
     GrantConfigTypeUrls {},

--- a/contracts/treasury/src/query.rs
+++ b/contracts/treasury/src/query.rs
@@ -1,4 +1,4 @@
-use crate::grant::{FeeConfig, GrantConfig};
+use crate::grant::{FeeConfig, FeeConfigStorage, GrantConfig, GrantConfigStorage};
 use crate::state::{Params, ADMIN, FEE_CONFIG, GRANT_CONFIGS, PARAMS, PENDING_ADMIN};
 use cosmwasm_std::{Addr, Order, StdResult, Storage};
 
@@ -23,8 +23,21 @@ pub fn grant_config_by_type_url(
         })
 }
 
-pub fn fee_config(store: &dyn Storage) -> StdResult<FeeConfig> {
+pub fn raw_grant_config_by_type_url(
+    store: &dyn Storage,
+    msg_type_url: String,
+) -> StdResult<GrantConfigStorage> {
+    GRANT_CONFIGS.load(store, msg_type_url)
+}
+
+pub fn raw_fee_config(store: &dyn Storage) -> StdResult<FeeConfigStorage> {
     FEE_CONFIG.load(store)
+}
+
+pub fn fee_config(store: &dyn Storage, address: String) -> StdResult<FeeConfig> {
+    FEE_CONFIG
+        .load(store)
+        .and_then(|fee_config| fee_config.try_into_fee_config(address).map_err(Into::into))
 }
 
 pub fn admin(store: &dyn Storage) -> StdResult<Addr> {

--- a/contracts/treasury/src/query.rs
+++ b/contracts/treasury/src/query.rs
@@ -12,8 +12,15 @@ pub fn grant_config_type_urls(store: &dyn Storage) -> StdResult<Vec<String>> {
 pub fn grant_config_by_type_url(
     store: &dyn Storage,
     msg_type_url: String,
+    account_address: String,
 ) -> StdResult<GrantConfig> {
-    GRANT_CONFIGS.load(store, msg_type_url)
+    GRANT_CONFIGS
+        .load(store, msg_type_url)
+        .and_then(|grant_config| {
+            grant_config
+                .try_into_grant_config(account_address)
+                .map_err(Into::into)
+        })
 }
 
 pub fn fee_config(store: &dyn Storage) -> StdResult<FeeConfig> {

--- a/contracts/treasury/src/state.rs
+++ b/contracts/treasury/src/state.rs
@@ -1,10 +1,10 @@
-use crate::grant::{FeeConfig, GrantConfig};
+use crate::grant::{FeeConfig, GrantConfigStorage};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
 
 // msg_type_url to grant config
-pub const GRANT_CONFIGS: Map<String, GrantConfig> = Map::new("grant_configs");
+pub const GRANT_CONFIGS: Map<String, GrantConfigStorage> = Map::new("grant_configs");
 
 pub const FEE_CONFIG: Item<FeeConfig> = Item::new("fee_config");
 

--- a/contracts/treasury/src/state.rs
+++ b/contracts/treasury/src/state.rs
@@ -1,4 +1,4 @@
-use crate::grant::{FeeConfig, GrantConfigStorage};
+use crate::grant::{FeeConfigStorage, GrantConfigStorage};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
@@ -6,7 +6,7 @@ use cw_storage_plus::{Item, Map};
 // msg_type_url to grant config
 pub const GRANT_CONFIGS: Map<String, GrantConfigStorage> = Map::new("grant_configs");
 
-pub const FEE_CONFIG: Item<FeeConfig> = Item::new("fee_config");
+pub const FEE_CONFIG: Item<FeeConfigStorage> = Item::new("fee_config");
 
 pub const ADMIN: Item<Addr> = Item::new("admin");
 


### PR DESCRIPTION
**THIS IS STILL A DRAFT**

## Description
<!-- Provide a brief description of the changes in this PR -->
We add the ability for treasury contracts to include the abstract account address inside the authz and fee grants. This allows more account interoperability and allows interacting with Abstract more easily. 

## Contract Details
Please append all the required information below for the contract(s) being added to `contracts.json`.

Required fields and their descriptions:
- `name`: Contract name (required)
- `description`: Brief description of the contract's purpose
- `code_id`: Contract code ID on mainnet
- `hash`: Contract hash in UPPERCASE
- `release`:
  - `url`: URL to the release/commit (e.g., https://github.com/org/repo/releases/tag/v1.0.0)
  - `version`: Version tag or first 7 chars of commit hash
- `author`:
  - `name`: Organization name
  - `url`: Organization website URL
- `governance`: "Genesis" or proposal number
- `deprecated`: true if contract is deprecated (mixed inline with active contracts)

Example JSON structure:
```json
{
  "name": "",
  "description": "",
  "code_id": "",
  "hash": "",
  "release": {
    "url": "",
    "version": ""
  },
  "author": {
    "name": "",
    "url": ""
  },
  "governance": "",
  "deprecated": false
}
```

### Finding Code ID and Hash
To find the latest code ID and hash:
1. Run the verification tool which will show all code IDs on chain:
   ```bash
   node scripts/verify-code-ids.js
   ```
2. The new code ID will be shown in the mismatches as "exists on chain but not in contracts.json"
3. You can also query the code hash via the chain's RPC endpoint:
   ```bash
   xiond query wasm code-info <code-id> --node https://rpc.xion-mainnet-1.burnt.com
   ```

### Documentation Updates
The README.md is automatically generated from `contracts.json`. After making changes:

1. Ensure you have the required dependencies:
   - Node.js: https://nodejs.org/
   - jq: `brew install jq` (macOS) or `apt-get install jq` (Ubuntu/Debian)

2. Run the convert script to validate and update the README:
   ```bash
   ./convert.sh
   ```

3. Commit both the `contracts.json` and generated `README.md` changes

⚠️ Important Notes:
- Do not edit README.md manually. All changes must be made through `contracts.json`
- Pull requests with manual README edits will be automatically rejected by CI
- If you forget to run `./convert.sh` locally, the CI will fail with a "README out of sync" error

### Validation
The `convert.sh` script automatically performs these validations:
- All required fields are present and properly formatted
- Hash is 64 characters and uppercase hex
- URLs are valid HTTPS links
- Code IDs are unique
- Contracts are ordered by code_id (both active and deprecated contracts follow the same ordering)
- README.md stays in sync with contracts.json

If any validation fails, the script will show specific error messages to help you fix the issues.

### Checklist
- [ ] Added entry to `contracts.json` with all required fields
- [ ] Contract name is clear and descriptive
- [ ] Description explains the contract's purpose
- [ ] Code ID matches the mainnet deployed code
- [ ] Hash is in uppercase and matches the stored code
- [ ] Release URL points to the correct tag/commit
- [ ] Version matches the release tag or commit hash
- [ ] Author information is correct with valid URL
- [ ] Governance field correctly references proposal or "Genesis"
- [ ] Deprecated flag is set appropriately
- [ ] Entry is placed in code_id order (regardless of deprecated status)
- [ ] Ran `./convert.sh` and fixed any validation errors
- [ ] Both `contracts.json` and generated `README.md` are included in the commit

### Additional Notes
<!-- Add any additional context or notes about the contract deployment here -->
