### PR TITLE
fix: use flat team slugs in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-* @burnt-labs/burnt-engineering/burnt-protocol
+* @burnt-labs/burnt-protocol
 
-.github/ @burnt-labs/burnt-engineering/burnt-devops
-vitest.config.ts @burnt-labs/burnt-engineering/burnt-devops
-eslint.config.* @burnt-labs/burnt-engineering/burnt-devops
+.github/ @burnt-labs/burnt-devops
+vitest.config.ts @burnt-labs/burnt-devops
+eslint.config.* @burnt-labs/burnt-devops


### PR DESCRIPTION
Use @burnt-labs/burnt-devops and @burnt-labs/burnt-protocol directly — nested team references are ignored by GitHub and cause unexpected ownership assignment.