### PR TITLE
Resolve all Dependabot vulnerabilities

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.86.0
+          toolchain: 1.88.0
           target: wasm32-unknown-unknown
           override: true
 
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.86.0
+          toolchain: 1.88.0
           override: true
           components: rustfmt, clippy
 
@@ -65,6 +65,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.88.0
+          target: wasm32-unknown-unknown
+          override: true
       - name: Build development contracts
-        run: |
-          docker run --rm -v "${PWD}:/code" cosmwasm/optimizer:0.17.0
+        run: cargo build --workspace --release --locked --target wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,17 +4,6 @@ version = 4
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -78,7 +67,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "itertools 0.10.5",
  "num-bigint",
  "num-traits",
@@ -132,7 +121,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.10.7",
+ "digest",
  "num-bigint",
 ]
 
@@ -162,11 +151,11 @@ dependencies = [
 name = "asset"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
- "cw721 0.20.0",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw2",
+ "cw721",
  "schemars",
  "serde",
  "thiserror 1.0.69",
@@ -220,16 +209,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
+ "digest",
 ]
 
 [[package]]
@@ -240,12 +220,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "bnum"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "bnum"
@@ -288,19 +262,6 @@ checksum = "35b6dc17e7fd89d0a0a58f12ef33f0bbdf09a6a14c3dfb383eae665e5889250e"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c82e56962f0f18c9a292aa59940e03a82ce15ef79b93679d5838bb8143f0df"
-dependencies = [
- "digest 0.10.7",
- "ed25519-zebra 3.1.0",
- "k256",
- "rand_core 0.6.4",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cosmwasm-crypto"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2f53285517db3e33d825b3e46301efe845135778527e1295154413b2f0469e"
@@ -310,26 +271,17 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "cosmwasm-core",
- "curve25519-dalek 4.1.3",
- "digest 0.10.7",
+ "curve25519-dalek",
+ "digest",
  "ecdsa",
- "ed25519-zebra 4.0.3",
+ "ed25519-zebra",
  "k256",
  "num-traits",
  "p256",
- "rand_core 0.6.4",
+ "rand_core",
  "rayon",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cosmwasm-derive"
-version = "1.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b804ff15a0e059c88f85ae0e868cf8c7aba9d61221e46f1ad7250f270628c7"
-dependencies = [
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -345,39 +297,15 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5526ea839acb47bbf8fff031ed9aad86e74d43f77b089255417328c3664367d5"
-dependencies = [
- "cosmwasm-schema-derive 1.5.11",
- "schemars",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cosmwasm-schema"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6984ab21b47a096e17ae4c73cea2123a704d4b6686c39421247ad67020d76f95"
 dependencies = [
- "cosmwasm-schema-derive 2.2.2",
+ "cosmwasm-schema-derive",
  "schemars",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cosmwasm-schema-derive"
-version = "1.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f41b99f41f840765d02ae858956bb52af910755976312082e90493c67db512"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -393,46 +321,24 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763340055b84e5482ed90fec8194ff7d59112267a09bbf5819c9e3edca8c052e"
-dependencies = [
- "base64 0.21.7",
- "bech32 0.9.1",
- "bnum 0.10.0",
- "cosmwasm-crypto 1.5.11",
- "cosmwasm-derive 1.5.11",
- "derivative",
- "forward_ref",
- "hex",
- "schemars",
- "serde",
- "serde-json-wasm 0.5.2",
- "sha2 0.10.9",
- "static_assertions",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cosmwasm-std"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf82335c14bd94eeb4d3c461b7aa419ecd7ea13c2efe24b97cd972bdb8044e7d"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.0",
- "bnum 0.11.0",
+ "bnum",
  "cosmwasm-core",
- "cosmwasm-crypto 2.2.2",
- "cosmwasm-derive 2.2.2",
+ "cosmwasm-crypto",
+ "cosmwasm-derive",
  "derive_more",
  "hex",
- "rand_core 0.6.4",
+ "rand_core",
  "rmp-serde",
  "schemars",
  "serde",
- "serde-json-wasm 1.0.1",
- "sha2 0.10.9",
+ "serde-json-wasm",
+ "sha2",
  "static_assertions",
  "thiserror 1.0.69",
 ]
@@ -484,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -501,19 +407,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
@@ -521,7 +414,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -545,7 +438,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73553ee4dad5b1678977ff603e72c3fdd41518ca2b0bd9b245b21e4c72eafa9e"
 dependencies = [
- "cosmwasm-std 2.2.2",
+ "cosmwasm-std",
 ]
 
 [[package]]
@@ -556,15 +449,15 @@ checksum = "683c799ba3a3d01933be5ef693c10cf815855967eb71c3dd730f2987ebb9316e"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw-utils",
  "itertools 0.14.0",
  "prost 0.14.1",
  "schemars",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 2.0.17",
 ]
 
@@ -574,12 +467,12 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2f8ee96ac5342c795a0610410998fc075a95af8c796b6d16479cdffd2471f1"
 dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
+ "cosmwasm-schema",
+ "cosmwasm-std",
  "cw-address-like",
  "cw-ownable-derive",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "thiserror 1.0.69",
 ]
 
@@ -607,40 +500,14 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b6f91c0b94481a3e9ef1ceb183c37d00764f8751e39b45fc09f4d9b970d469"
-dependencies = [
- "cosmwasm-std 1.5.11",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw-storage-plus"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f13360e9007f51998d42b1bc6b7fa0141f74feae61ed5fd1e5b0a89eec7b5de1"
 dependencies = [
- "cosmwasm-std 2.2.2",
+ "cosmwasm-std",
  "cw-storage-macro",
  "schemars",
  "serde",
-]
-
-[[package]]
-name = "cw-utils"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a84c6c1c0acc3616398eba50783934bd6c964bad6974241eaee3460c8f5b26"
-dependencies = [
- "cosmwasm-schema 1.5.11",
- "cosmwasm-std 1.5.11",
- "cw2 0.16.0",
- "schemars",
- "semver",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -649,24 +516,11 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07dfee7f12f802431a856984a32bce1cb7da1e6c006b5409e3981035ce562dec"
 dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
+ "cosmwasm-schema",
+ "cosmwasm-std",
  "schemars",
  "serde",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cw2"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
-dependencies = [
- "cosmwasm-schema 1.5.11",
- "cosmwasm-std 1.5.11",
- "cw-storage-plus 0.16.0",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -675,9 +529,9 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b04852cd38f044c0751259d5f78255d07590d136b8a86d4e09efdd7666bd6d27"
 dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
  "schemars",
  "semver",
  "serde",
@@ -686,30 +540,16 @@ dependencies = [
 
 [[package]]
 name = "cw721"
-version = "0.16.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a1ea6e6277bdd6dfc043a9b1380697fe29d6e24b072597439523658d21d791"
+checksum = "e401c776c2c63e602061e1a260c0ec5e2088699f4c3cacd2bbd4de8db7d6991d"
 dependencies = [
- "cosmwasm-schema 1.5.11",
- "cosmwasm-std 1.5.11",
- "cw-utils 0.16.0",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw721"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f67636cad1becbc9fee3e18e93c97a1c8b157fc6a875817178a14c301e40fdf"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
+ "cosmwasm-schema",
+ "cosmwasm-std",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
- "cw2 2.0.0",
- "cw721 0.16.0",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
  "schemars",
  "serde",
  "thiserror 1.0.69",
@@ -718,15 +558,15 @@ dependencies = [
 
 [[package]]
 name = "cw721-base"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3671b8e76ab8c22113e8d5b6e4bffbfb5df69a44cae99657a361941b95b6ca"
+checksum = "676c47ec2e90a03bf8db6717d8916f722bcec38367d2b867608bcf4ac42a3724"
 dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
+ "cosmwasm-schema",
+ "cosmwasm-std",
  "cw-ownable",
- "cw2 2.0.0",
- "cw721 0.20.0",
+ "cw2",
+ "cw721",
  "serde",
 ]
 
@@ -746,6 +586,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derivative"
@@ -781,20 +624,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -824,7 +658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "serdect",
@@ -843,31 +677,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "hashbrown 0.12.3",
- "hex",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-zebra"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "ed25519",
  "hashbrown 0.14.5",
  "hex",
- "rand_core 0.6.4",
- "sha2 0.10.9",
+ "rand_core",
+ "sha2",
  "zeroize",
 ]
 
@@ -885,13 +704,13 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "serdect",
  "subtle",
@@ -904,7 +723,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -931,12 +750,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "forward_ref"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "generic-array"
@@ -967,17 +780,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
 ]
 
 [[package]]
@@ -986,7 +790,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
 ]
 
 [[package]]
@@ -995,7 +799,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -1011,7 +815,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1164,9 +968,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2 0.10.9",
- "signature",
+ "sha2",
 ]
 
 [[package]]
@@ -1271,12 +1073,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,7 +1082,7 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "serdect",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1436,7 +1232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1446,14 +1242,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -1500,7 +1290,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1532,13 +1322,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
- "digest 0.10.7",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "signature",
  "spki",
  "subtle",
@@ -1617,15 +1407,6 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde-json-wasm"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05da0d153dd4595bdffd5099dc0e9ce425b205ee648eb93437ff7302af8c9a5"
@@ -1699,26 +1480,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1727,8 +1495,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1870,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1883,15 +1651,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.32"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1920,10 +1688,10 @@ dependencies = [
 name = "treasury"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw2",
  "schemars",
  "serde",
  "serde_json",
@@ -1966,10 +1734,10 @@ dependencies = [
 name = "user-map"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw2",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2005,10 +1773,10 @@ version = "0.1.1"
 dependencies = [
  "base64 0.21.7",
  "bech32 0.9.1",
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw2",
  "getrandom",
  "hex",
  "p256",
@@ -2017,7 +1785,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
  "tiny-keccak",
  "xion-cosmos-sdk-proto",
@@ -2042,14 +1810,14 @@ dependencies = [
  "anyhow",
  "asset",
  "blake2",
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
+ "cosmwasm-schema",
+ "cosmwasm-std",
  "cw-address-like",
  "cw-multi-test",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
- "cw2 2.0.0",
- "cw721 0.20.0",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
+ "cw721",
  "cw721-base",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -743,12 +743,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derivative"
@@ -1233,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1434,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_chacha",
  "rand_core 0.6.4",
@@ -1873,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1886,15 +1883,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ cw-address-like = "2.0.0"
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"
 cw2 = "2.0.0"
-cw721 = "0.20.0"
-cw721-base = "0.20.0"
+cw721 = "0.21.0"
+cw721-base = "0.21.0"
 ed25519-zebra = { version = "=4.0.3", default-features = false }
 getrandom = { version = "0.2.10", features = ["custom"] }
 hex = "0.4"

--- a/contracts/account/src/error.rs
+++ b/contracts/account/src/error.rs
@@ -99,12 +99,12 @@ pub type ContractResult<T> = Result<T, ContractError>;
 
 impl From<p256::ecdsa::Error> for ContractError {
     fn from(value: p256::ecdsa::Error) -> Self {
-        Self::P256EcdsaCurve(format!("{:?}", value))
+        Self::P256EcdsaCurve(format!("{value:?}"))
     }
 }
 
 impl From<serde_json::Error> for ContractError {
     fn from(value: serde_json::Error) -> Self {
-        Self::SerdeJSON(format!("{:?}", value))
+        Self::SerdeJSON(format!("{value:?}"))
     }
 }

--- a/contracts/asset/src/default_plugins.rs
+++ b/contracts/asset/src/default_plugins.rs
@@ -67,8 +67,7 @@ pub fn min_price_plugin(ctx: &mut PluginCtx<DefaultXionAssetContext, Empty>) -> 
             }
             if ask_price.amount.u128() < min_price.amount.u128() {
                 return Err(cosmwasm_std::StdError::generic_err(format!(
-                    "Minimum price not met: {} required, {} provided",
-                    min_price, ask_price
+                    "Minimum price not met: {min_price} required, {ask_price} provided"
                 )));
             }
         } else {

--- a/contracts/asset/src/plugin.rs
+++ b/contracts/asset/src/plugin.rs
@@ -106,20 +106,20 @@ pub enum Plugin {
 impl Display for Plugin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Plugin::ExactPrice { amount } => write!(f, "ExactPrice: {}", amount),
-            Plugin::MinimumPrice { amount } => write!(f, "MinimumPrice: {}", amount),
-            Plugin::RequiresProof { proof } => write!(f, "RequiresProof: {:?}", proof),
-            Plugin::NotBefore { time } => write!(f, "NotBefore: {}", time),
-            Plugin::NotAfter { time } => write!(f, "NotAfter: {}", time),
-            Plugin::TimeLock { time } => write!(f, "TimeLock: {:?}", time),
+            Plugin::ExactPrice { amount } => write!(f, "ExactPrice: {amount}"),
+            Plugin::MinimumPrice { amount } => write!(f, "MinimumPrice: {amount}"),
+            Plugin::RequiresProof { proof } => write!(f, "RequiresProof: {proof:?}"),
+            Plugin::NotBefore { time } => write!(f, "NotBefore: {time}"),
+            Plugin::NotAfter { time } => write!(f, "NotAfter: {time}"),
+            Plugin::TimeLock { time } => write!(f, "TimeLock: {time:?}"),
             Plugin::Royalty { bps, recipient } => {
-                write!(f, "Royalty: {} bps to {}", bps, recipient)
+                write!(f, "Royalty: {bps} bps to {recipient}")
             }
             Plugin::AllowedMarketplaces { marketplaces } => {
-                write!(f, "AllowedMarketplaces: {:?}", marketplaces)
+                write!(f, "AllowedMarketplaces: {marketplaces:?}")
             }
             Plugin::AllowedCurrencies { denoms } => {
-                write!(f, "AllowedCurrencies: {:?}", denoms)
+                write!(f, "AllowedCurrencies: {denoms:?}")
             }
         }
     }

--- a/contracts/asset/src/tests/execute/helpers.rs
+++ b/contracts/asset/src/tests/execute/helpers.rs
@@ -1,7 +1,7 @@
 pub(crate) fn expect_ok<T, E: core::fmt::Debug>(res: Result<T, E>) -> T {
     match res {
         Ok(value) => value,
-        Err(err) => panic!("expected Ok(..) but got Err({:?})", err),
+        Err(err) => panic!("expected Ok(..) but got Err({err:?})"),
     }
 }
 

--- a/contracts/asset/src/tests/plugin/default_plugins.rs
+++ b/contracts/asset/src/tests/plugin/default_plugins.rs
@@ -185,7 +185,7 @@ fn royalty_plugin_creates_deduction_and_message() {
             assert_eq!(to_address, "artist");
             assert_eq!(amount, &vec![Coin::new(50u128, "uxion")]);
         }
-        other => panic!("unexpected message: {:?}", other),
+        other => panic!("unexpected message: {other:?}"),
     }
 }
 
@@ -211,7 +211,7 @@ fn royalty_plugin_rounds_up_small_amounts() {
             assert_eq!(to_address, "artist");
             assert_eq!(amount, &vec![Coin::new(1u128, "uxion")]);
         }
-        other => panic!("unexpected message: {:?}", other),
+        other => panic!("unexpected message: {other:?}"),
     }
 }
 

--- a/contracts/asset/src/tests/plugin/pluggable.rs
+++ b/contracts/asset/src/tests/plugin/pluggable.rs
@@ -309,7 +309,7 @@ fn on_buy_plugin_runs_allowed_marketplace_and_royalty_plugins() {
             assert_eq!(to_address, &royalty_recipient.to_string());
             assert_eq!(amount, &vec![Coin::new(5u128, "uxion")]);
         }
-        msg => panic!("unexpected message: {:?}", msg),
+        msg => panic!("unexpected message: {msg:?}"),
     }
     let amount_attr = ctx
         .response

--- a/contracts/asset/src/tests/plugin/sellable.rs
+++ b/contracts/asset/src/tests/plugin/sellable.rs
@@ -95,10 +95,10 @@ fn buy_deducts_royalty_fees() {
                 } else if *to_address == royalty_recipient.to_string() {
                     royalty_paid = Some(coin);
                 } else {
-                    panic!("unexpected recipient {}", to_address);
+                    panic!("unexpected recipient {to_address}");
                 }
             }
-            other => panic!("unexpected message: {:?}", other),
+            other => panic!("unexpected message: {other:?}"),
         }
     }
 

--- a/contracts/asset/src/traits.rs
+++ b/contracts/asset/src/traits.rs
@@ -284,7 +284,7 @@ where
             AssetExtensionExecuteMsg::RemoveCollectionPlugin { plugins } => {
                 self.remove_plugin(deps, env, info, &plugins)?;
                 Ok(Response::new()
-                    .add_attribute("action", format!("remove_collection_plugin {:?}", plugins)))
+                    .add_attribute("action", format!("remove_collection_plugin {plugins:?}")))
             }
         }
     }

--- a/contracts/marketplace/tests/tests/test_accept_offer.rs
+++ b/contracts/marketplace/tests/tests/test_accept_offer.rs
@@ -98,7 +98,7 @@ fn test_accept_offer_fee_routing() {
     );
 
     if let Err(ref e) = accept_result {
-        println!("Accept offer error: {:?}", e);
+        println!("Accept offer error: {e:?}");
     }
     assert!(accept_result.is_ok());
 

--- a/contracts/marketplace/tests/tests/test_approval_queue.rs
+++ b/contracts/marketplace/tests/tests/test_approval_queue.rs
@@ -1074,7 +1074,7 @@ fn test_approve_sale_fee_routing_with_zero_fee() {
     );
 
     if let Err(ref e) = approve_result {
-        println!("Approve sale error with zero fee: {:?}", e);
+        println!("Approve sale error with zero fee: {e:?}");
     }
     assert!(approve_result.is_ok());
 
@@ -1331,7 +1331,7 @@ fn test_approve_sale_with_existing_pending_sale() {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let token_id = format!("test_approve_existing_pending_{}", timestamp);
+    let token_id = format!("test_approve_existing_pending_{timestamp}");
     mint_nft(&mut app, &asset_contract, &minter, &seller, &token_id);
 
     let price = coin(100, "uxion");

--- a/contracts/marketplace/tests/tests/test_buy_item.rs
+++ b/contracts/marketplace/tests/tests/test_buy_item.rs
@@ -87,8 +87,8 @@ fn test_buy_item_success() {
             assert!(listing_resp.is_err());
         }
         Err(error) => {
-            println!("Error: {:?}", error);
-            panic!("Buy item failed: {:?}", error);
+            println!("Error: {error:?}");
+            panic!("Buy item failed: {error:?}");
         }
     }
 }
@@ -507,22 +507,19 @@ fn test_buy_item_success_with_royalties() {
     assert_eq!(
         seller_balance_after.u128(),
         seller_balance_before.u128() + expected_seller_payment,
-        "Seller should receive {} uxion (1000 - 25 marketplace fee - 50 royalty)",
-        expected_seller_payment
+        "Seller should receive {expected_seller_payment} uxion (1000 - 25 marketplace fee - 50 royalty)"
     );
 
     assert_eq!(
         manager_balance_after,
         manager_balance_before + Uint128::from(expected_marketplace_fee),
-        "Manager should receive {} uxion marketplace fee",
-        expected_marketplace_fee
+        "Manager should receive {expected_marketplace_fee} uxion marketplace fee"
     );
 
     assert_eq!(
         royalty_recipient_balance_after,
         royalty_recipient_balance_before + Uint128::from(expected_royalty),
-        "Royalty recipient should receive {} uxion royalty",
-        expected_royalty
+        "Royalty recipient should receive {expected_royalty} uxion royalty"
     );
 
     let owner_query = cw721_base::msg::QueryMsg::OwnerOf {

--- a/contracts/user_map/src/contract.rs
+++ b/contracts/user_map/src/contract.rs
@@ -127,7 +127,7 @@ mod tests {
 
         // valid JSON, but total length exceeds the cap
         let too_long = "a".repeat(MAX_VALUE_LEN + 1);
-        let value = format!("{{\"k\":\"{}\"}}", too_long);
+        let value = format!("{{\"k\":\"{too_long}\"}}");
 
         let err = execute(
             deps.as_mut(),


### PR DESCRIPTION
## Summary

- incorporate the secure Dependabot updates for bytes, rand, and time
- upgrade CW721 to remove the legacy CosmWasm 1 dependency and vulnerable curve25519-dalek 3.x graph
- move CI to Rust 1.88, the minimum toolchain supported by the first patched time release
- keep strict Clippy green with compiler-suggested format-string migrations
- replace the Rust 1.86 optimizer-based PR build with a locked Rust 1.88 workspace Wasm build

## Why

The existing Dependabot PR covers only three of four alerts and fails because its time update requires Rust 1.88. CW721 0.20 also retains a compatibility dependency on CosmWasm 1, leaving curve25519-dalek 3.2.0 in the lockfile. This PR resolves all four current default-branch alerts together.

## Validation

- cargo +1.88.0 fmt --all -- --check
- cargo +1.88.0 clippy --workspace --all-targets --locked -- -D warnings
- cargo +1.88.0 test --workspace --locked (122 passed)
- cargo +1.88.0 build --workspace --release --locked --target wasm32-unknown-unknown
- dependency tree contains only curve25519-dalek 4.1.3
- dependency tree resolves bytes 1.12.1, rand 0.8.7, and time 0.3.47
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the contract build and validation process to use newer Rust tooling.
  - Refreshed NFT-related contract libraries for improved compatibility.
  - Replaced the container-based optimization step with a streamlined native build process.

- **Maintenance**
  - Modernized formatting throughout contract messages and diagnostics without changing their content or behavior.
  - Updated test output formatting while preserving existing assertions and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->